### PR TITLE
Add initial Flutter scaffolding

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'screens/imagine_screen.dart';
+import 'screens/accumulation_screen.dart';
+import 'screens/desync_screen.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final games = <_GameEntry>[
+      _GameEntry('Imagine', const ImagineScreen()),
+      _GameEntry('Accumulation', const AccumulationScreen()),
+      _GameEntry('DeSync', const DesyncScreen()),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reading Speedster')),
+      body: GridView.count(
+        crossAxisCount: 2,
+        padding: const EdgeInsets.all(16),
+        mainAxisSpacing: 16,
+        crossAxisSpacing: 16,
+        children: games
+            .map(
+              (e) => ElevatedButton(
+                style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(8)),
+                onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => e.screen),
+                ),
+                child: Text(e.name, textAlign: TextAlign.center),
+              ),
+            )
+            .toList(),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: Colors.deepOrange),
+              child: Center(child: Text('Menu')),
+            ),
+            ListTile(
+              leading: const Icon(Icons.info_outline),
+              title: const Text('Tutorial'),
+              onTap: () {},
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Settings'),
+              onTap: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GameEntry {
+  final String name;
+  final Widget screen;
+  const _GameEntry(this.name, this.screen);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,17 @@
 import 'package:flutter/material.dart';
+import 'home_page.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+void main() => runApp(const ReadingSpeedster());
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class ReadingSpeedster extends StatelessWidget {
+  const ReadingSpeedster({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'Reading Speedster',
+      theme: ThemeData.dark(),
+      home: const HomePage(),
     );
   }
 }

--- a/lib/screens/accumulation_screen.dart
+++ b/lib/screens/accumulation_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AccumulationScreen extends StatelessWidget {
+  const AccumulationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Accumulation')),
+      body: const Center(child: Text('Accumulation game coming soon')),
+    );
+  }
+}

--- a/lib/screens/desync_screen.dart
+++ b/lib/screens/desync_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class DesyncScreen extends StatelessWidget {
+  const DesyncScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DeSync')),
+      body: const Center(child: Text('DeSync game coming soon')),
+    );
+  }
+}

--- a/lib/screens/imagine_screen.dart
+++ b/lib/screens/imagine_screen.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+class ImagineScreen extends StatefulWidget {
+  const ImagineScreen({super.key});
+
+  @override
+  State<ImagineScreen> createState() => _ImagineScreenState();
+}
+
+class _ImagineScreenState extends State<ImagineScreen> {
+  final _words = ['wizardry', 'science', 'flutter'];
+  late Timer _timer;
+  int _index = 0;
+  bool _showWord = true;
+  double displaySeconds = 2.0;
+  TextStyle style = const TextStyle(fontSize: 40);
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(
+      Duration(milliseconds: (displaySeconds * 1000).round()),
+      (_) {
+        setState(() {
+          _showWord = !_showWord;
+          if (_showWord) {
+            _index = (_index + 1) % _words.length;
+          }
+        });
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Imagine')),
+      body: Center(
+        child:
+            _showWord ? Text(_words[_index], style: style) : const SizedBox.shrink(),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,89 +1,41 @@
 name: readingspeedster
-description: "Learnign how to read better"
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+description: "Learning how to read better"
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1
 
 environment:
   sdk: ^3.9.0
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package
+  assets:
+    - assets/
+  fonts:
+    - family: Serif
+      fonts:
+        - asset: assets/fonts/serif.otf
+        - asset: assets/fonts/serif-italic.otf
+          style: italic
+    - family: Calibri
+      fonts:
+        - asset: assets/fonts/calibri.ttf
+    - family: Arial
+      fonts:
+        - asset: assets/fonts/arial.ttf
+    - family: TimesNewRoman
+      fonts:
+        - asset: assets/fonts/times-new-roman.ttf
+    - family: Ubuntu
+      fonts:
+        - asset: assets/fonts/ubuntu.ttf


### PR DESCRIPTION
## Summary
- Replace counter app with ReadingSpeedster app entry point
- Add HomePage grid and placeholder game screens
- Configure assets and fonts in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7973a148c8322a0275bc087d9c563