### PR TITLE
Add .gitignore for Flutter and Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Flutter & Dart
+.dart_tool/
+.packages
+.pub/
+build/
+flutter_*.symlinks/
+flutter_export_environment.sh
+generated_plugin_registrant.dart
+
+# IntelliJ / Android Studio
+*.iml
+.idea/
+.gradle/
+
+# Miscellaneous
+.DS_Store
+*.log
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+dist/
+build/
+venv/
+.venv/
+env/
+.env/
+*.db
+*.spec


### PR DESCRIPTION
## Summary
- add comprehensive `.gitignore` to exclude Flutter build files and Python artifacts

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ef3624c8322b8e22368b834bc1f