### PR TITLE
feat: add generic game setup flow

### DIFF
--- a/lib/core/game.dart
+++ b/lib/core/game.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+
+/// Base class for all game configuration objects.
+abstract class GameConfig {
+  String article;
+  GameConfig({required this.article});
+}
+
+/// Base interface for games.
+abstract class Game {
+  /// Display name for the game.
+  String get name;
+
+  /// List of available articles for practice.
+  List<String> get articles;
+
+  /// Create a default configuration for this game.
+  GameConfig createConfig();
+
+  /// Build widgets to configure game specific settings.
+  Widget settingsBuilder(GameConfig config, ValueChanged<GameConfig> onChanged);
+
+  /// Build the practice widget using the provided configuration.
+  Widget buildPractice(GameConfig config);
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'core/game.dart';
+import 'screens/game_setup_screen.dart';
 import 'screens/imagine_screen.dart';
 import 'screens/accumulation_screen.dart';
 import 'screens/desync_screen.dart';
@@ -8,10 +10,10 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final games = <_GameEntry>[
-      _GameEntry('Imagine', const ImagineScreen()),
-      _GameEntry('Accumulation', const AccumulationScreen()),
-      _GameEntry('DeSync', const DesyncScreen()),
+    final games = <Game>[
+      ImagineGame(),
+      AccumulationGame(),
+      DesyncGame(),
     ];
 
     return Scaffold(
@@ -23,13 +25,15 @@ class HomePage extends StatelessWidget {
         crossAxisSpacing: 16,
         children: games
             .map(
-              (e) => ElevatedButton(
+              (game) => ElevatedButton(
                 style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(8)),
                 onPressed: () => Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => e.screen),
+                  MaterialPageRoute(
+                    builder: (_) => GameSetupScreen(game: game),
+                  ),
                 ),
-                child: Text(e.name, textAlign: TextAlign.center),
+                child: Text(game.name, textAlign: TextAlign.center),
               ),
             )
             .toList(),
@@ -56,10 +60,4 @@ class HomePage extends StatelessWidget {
       ),
     );
   }
-}
-
-class _GameEntry {
-  final String name;
-  final Widget screen;
-  const _GameEntry(this.name, this.screen);
 }

--- a/lib/screens/accumulation_screen.dart
+++ b/lib/screens/accumulation_screen.dart
@@ -1,7 +1,30 @@
 import 'package:flutter/material.dart';
+import '../core/game.dart';
 
-class AccumulationScreen extends StatelessWidget {
-  const AccumulationScreen({super.key});
+class _AccumulationConfig extends GameConfig {
+  _AccumulationConfig({required super.article});
+}
+
+class AccumulationGame extends Game {
+  @override
+  String get name => 'Accumulation';
+
+  @override
+  List<String> get articles => const ['Sample'];
+
+  @override
+  GameConfig createConfig() => _AccumulationConfig(article: articles.first);
+
+  @override
+  Widget settingsBuilder(GameConfig config, ValueChanged<GameConfig> onChanged) =>
+      const SizedBox.shrink();
+
+  @override
+  Widget buildPractice(GameConfig config) => const _AccumulationPractice();
+}
+
+class _AccumulationPractice extends StatelessWidget {
+  const _AccumulationPractice();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/desync_screen.dart
+++ b/lib/screens/desync_screen.dart
@@ -1,7 +1,30 @@
 import 'package:flutter/material.dart';
+import '../core/game.dart';
 
-class DesyncScreen extends StatelessWidget {
-  const DesyncScreen({super.key});
+class _DesyncConfig extends GameConfig {
+  _DesyncConfig({required super.article});
+}
+
+class DesyncGame extends Game {
+  @override
+  String get name => 'DeSync';
+
+  @override
+  List<String> get articles => const ['Sample'];
+
+  @override
+  GameConfig createConfig() => _DesyncConfig(article: articles.first);
+
+  @override
+  Widget settingsBuilder(GameConfig config, ValueChanged<GameConfig> onChanged) =>
+      const SizedBox.shrink();
+
+  @override
+  Widget buildPractice(GameConfig config) => const _DesyncPractice();
+}
+
+class _DesyncPractice extends StatelessWidget {
+  const _DesyncPractice();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/game_setup_screen.dart
+++ b/lib/screens/game_setup_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../core/game.dart';
+
+/// Screen allowing the user to choose article and configure settings
+/// before starting the practice for a [Game].
+class GameSetupScreen extends StatefulWidget {
+  final Game game;
+  const GameSetupScreen({super.key, required this.game});
+
+  @override
+  State<GameSetupScreen> createState() => _GameSetupScreenState();
+}
+
+class _GameSetupScreenState extends State<GameSetupScreen> {
+  late GameConfig _config;
+
+  @override
+  void initState() {
+    super.initState();
+    _config = widget.game.createConfig();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Setup ${widget.game.name}')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Article'),
+            DropdownButton<String>(
+              value: _config.article,
+              items: widget.game.articles
+                  .map((a) => DropdownMenuItem(value: a, child: Text(a)))
+                  .toList(),
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() => _config.article = value);
+              },
+            ),
+            const SizedBox(height: 16),
+            widget.game.settingsBuilder(_config, (newConfig) {
+              setState(() => _config = newConfig);
+            }),
+            const Spacer(),
+            Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => widget.game.buildPractice(_config),
+                    ),
+                  );
+                },
+                child: const Text('Start Practice'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/imagine_screen.dart
+++ b/lib/screens/imagine_screen.dart
@@ -1,31 +1,80 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import '../core/game.dart';
 
-class ImagineScreen extends StatefulWidget {
-  const ImagineScreen({super.key});
-
-  @override
-  State<ImagineScreen> createState() => _ImagineScreenState();
+class ImagineConfig extends GameConfig {
+  double displaySeconds;
+  ImagineConfig({required super.article, this.displaySeconds = 2.0});
 }
 
-class _ImagineScreenState extends State<ImagineScreen> {
-  final _words = ['wizardry', 'science', 'flutter'];
+class ImagineGame extends Game {
+  static const Map<String, List<String>> _articles = {
+    'Sample': ['wizardry', 'science', 'flutter'],
+    'Tech': ['binary', 'widget', 'state'],
+  };
+
+  @override
+  String get name => 'Imagine';
+
+  @override
+  List<String> get articles => _articles.keys.toList();
+
+  @override
+  ImagineConfig createConfig() => ImagineConfig(article: articles.first);
+
+  @override
+  Widget settingsBuilder(GameConfig config, ValueChanged<GameConfig> onChanged) {
+    final c = config as ImagineConfig;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Display Seconds: ${c.displaySeconds.toStringAsFixed(1)}'),
+        Slider(
+          min: 0.5,
+          max: 5,
+          divisions: 9,
+          value: c.displaySeconds,
+          label: c.displaySeconds.toStringAsFixed(1),
+          onChanged: (v) => onChanged(
+            ImagineConfig(article: c.article, displaySeconds: v),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget buildPractice(GameConfig config) {
+    final c = config as ImagineConfig;
+    final words = _articles[c.article] ?? [];
+    return ImaginePractice(words: words, displaySeconds: c.displaySeconds);
+  }
+}
+
+class ImaginePractice extends StatefulWidget {
+  final List<String> words;
+  final double displaySeconds;
+  const ImaginePractice({super.key, required this.words, required this.displaySeconds});
+
+  @override
+  State<ImaginePractice> createState() => _ImaginePracticeState();
+}
+
+class _ImaginePracticeState extends State<ImaginePractice> {
   late Timer _timer;
   int _index = 0;
   bool _showWord = true;
-  double displaySeconds = 2.0;
-  TextStyle style = const TextStyle(fontSize: 40);
 
   @override
   void initState() {
     super.initState();
     _timer = Timer.periodic(
-      Duration(milliseconds: (displaySeconds * 1000).round()),
+      Duration(milliseconds: (widget.displaySeconds * 1000).round()),
       (_) {
         setState(() {
           _showWord = !_showWord;
           if (_showWord) {
-            _index = (_index + 1) % _words.length;
+            _index = (_index + 1) % widget.words.length;
           }
         });
       },
@@ -43,8 +92,9 @@ class _ImagineScreenState extends State<ImagineScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Imagine')),
       body: Center(
-        child:
-            _showWord ? Text(_words[_index], style: style) : const SizedBox.shrink(),
+        child: _showWord && widget.words.isNotEmpty
+            ? Text(widget.words[_index], style: const TextStyle(fontSize: 40))
+            : const SizedBox.shrink(),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- introduce `Game` and `GameConfig` abstractions
- refactor game screens into `Game` implementations
- add `GameSetupScreen` for article and settings selection
- hook `HomePage` to setup flow

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get install -y dart-sdk` *(fails: Unable to locate package dart-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68ab10d4e840832286e4466494b9ade4