### PR TITLE
Add widget tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test

--- a/test/accumulation_screen_test.dart
+++ b/test/accumulation_screen_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:readingspeedster/screens/accumulation_screen.dart';
+
+void main() {
+  testWidgets('Accumulation screen shows placeholder text', (WidgetTester tester) async {
+    final game = AccumulationGame();
+    final config = game.createConfig();
+
+    await tester.pumpWidget(MaterialApp(home: game.buildPractice(config)));
+
+    expect(find.text('Accumulation game coming soon'), findsOneWidget);
+  });
+}

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:readingspeedster/home_page.dart';
+
+void main() {
+  testWidgets('HomePage shows available games', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomePage()));
+
+    expect(find.text('Imagine'), findsOneWidget);
+    expect(find.text('Accumulation'), findsOneWidget);
+    expect(find.text('Desync'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget test coverage for HomePage and Accumulation screen
- run analyzer and tests in GitHub Actions to maintain code quality

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab150d0f0c8322bcb219306883e1ad