### PR TITLE
Add navigation and placeholder screens

### DIFF
--- a/lib/data/article_service.dart
+++ b/lib/data/article_service.dart
@@ -1,0 +1,10 @@
+import 'models/article.dart';
+import 'repositories/article_repository.dart';
+
+/// Simple service wrapper around [ArticleRepository].
+class ArticleService {
+  final ArticleRepository _repository = ArticleRepository();
+
+  Future<List<Article>> loadArticles() => _repository.fetchArticles();
+}
+

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -4,6 +4,10 @@ import 'screens/game_setup_screen.dart';
 import 'screens/imagine_screen.dart';
 import 'screens/accumulation_screen.dart';
 import 'screens/desync_screen.dart';
+import 'screens/text_prep_screen.dart';
+import 'screens/olaksaonica_screen.dart';
+import 'screens/tekstovi_screen.dart';
+import 'screens/dynamic_screen.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -44,6 +48,58 @@ class HomePage extends StatelessWidget {
             const DrawerHeader(
               decoration: BoxDecoration(color: Colors.deepOrange),
               child: Center(child: Text('Menu')),
+            ),
+            ListTile(
+              leading: const Icon(Icons.text_fields),
+              title: const Text('Text Prep'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TextPrepScreen(),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.library_books),
+              title: const Text('Tekstovi'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TekstoviScreen(),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.lightbulb_outline),
+              title: const Text('Olaksaonica'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const OlaksaonicaScreen(),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.dynamic_feed),
+              title: const Text('Dynamic'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const DynamicScreen(),
+                  ),
+                );
+              },
             ),
             ListTile(
               leading: const Icon(Icons.info_outline),

--- a/lib/screens/dynamic_screen.dart
+++ b/lib/screens/dynamic_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder screen for dynamic reading practice.
+class DynamicScreen extends StatelessWidget {
+  const DynamicScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dynamic')),
+      body: const Center(
+        child: Text('Dynamic practice coming soon'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/olaksaonica_screen.dart
+++ b/lib/screens/olaksaonica_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder screen for the Olaksaonica exercise.
+class OlaksaonicaScreen extends StatelessWidget {
+  const OlaksaonicaScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Olaksaonica')),
+      body: const Center(
+        child: Text('Olaksaonica content coming soon'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/tekstovi_screen.dart
+++ b/lib/screens/tekstovi_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../data/article_service.dart';
+import '../data/models/article.dart';
+
+/// Screen displaying available articles loaded from the database.
+class TekstoviScreen extends StatefulWidget {
+  const TekstoviScreen({super.key});
+
+  @override
+  State<TekstoviScreen> createState() => _TekstoviScreenState();
+}
+
+class _TekstoviScreenState extends State<TekstoviScreen> {
+  final ArticleService _service = ArticleService();
+  late Future<List<Article>> _articles;
+
+  @override
+  void initState() {
+    super.initState();
+    _articles = _service.loadArticles();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tekstovi')),
+      body: FutureBuilder<List<Article>>(
+        future: _articles,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final data = snapshot.data;
+          if (data == null || data.isEmpty) {
+            return const Center(child: Text('No articles available'));
+          }
+          return ListView.separated(
+            itemCount: data.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final article = data[index];
+              return ListTile(
+                title: Text(article.naslov),
+                onTap: () => _showArticle(context, article),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _showArticle(BuildContext context, Article article) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(article.naslov),
+        content: SingleChildScrollView(child: Text(article.text)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/screens/text_prep_screen.dart
+++ b/lib/screens/text_prep_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// Screen allowing users to paste or type a text and prepare it for practice.
+class TextPrepScreen extends StatelessWidget {
+  const TextPrepScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = TextEditingController();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Text Prep')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Paste or type your text below:'),
+            const SizedBox(height: 8),
+            Expanded(
+              child: TextField(
+                controller: controller,
+                expands: true,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  alignLabelWithHint: true,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () {
+                  // Placeholder for text preparation logic.
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Text prepared')),
+                  );
+                },
+                child: const Text('Prepare'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add TextPrep screen for entering and preparing text
- load database articles in Tekstovi screen via new ArticleService
- hook up Olaksaonica and Dynamic placeholder screens in the home drawer

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18a100508322ad8ec1a64803902b